### PR TITLE
:penguin: Add shortcut for color-picker:open for GNU/Linux and Windows.

### DIFF
--- a/keymaps/color-picker.cson
+++ b/keymaps/color-picker.cson
@@ -11,4 +11,4 @@
   'cmd-C': 'color-picker:open'
 
 '.platform-win32 .workspace, .platform-linux .workspace':
-  'ctrl-alt-shift-C': 'color-picker:open'
+  'ctrl-alt-c': 'color-picker:open'


### PR DESCRIPTION
ctrl-alt-shift-C does not clash with any builtin packages.
