### PR TITLE
interrupt “color-picker:open” command if editor is unavailable

### DIFF
--- a/lib/ColorPicker.coffee
+++ b/lib/ColorPicker.coffee
@@ -81,13 +81,15 @@
                 return _match
 
             open: (getMatch = false) ->
+                _editor = atom.workspace.getActiveEditor()
+                return unless _editor
                 if getMatch then @match = @getMatchAtCursor()
 
                 if not @match
                     randomRGBFragment = -> (Math.random() * 255) << 0
 
                     _line = '#' + Convert.rgbToHex [randomRGBFragment(), randomRGBFragment(), randomRGBFragment()]
-                    _cursorBuffer = atom.workspace.getActiveEditor().getCursorBufferPosition()
+                    _cursorBuffer = _editor.getCursorBufferPosition()
                     _cursorRow = _cursorBuffer.row
                     _cursorColumn = _cursorBuffer.column
 


### PR DESCRIPTION
Fixed a bug causing “Uncaught TypeError: Cannot read property 'getCursorBufferPosition' of undefined” error appears when accidentally calling color-picker from screen with no editor available, for example, settings screen (see attached screenshot).
![screenshot 2014-11-16 20 47 08](https://cloud.githubusercontent.com/assets/742056/5061646/0ee19cca-6dd2-11e4-89a7-5f3a4deecbfc.png)
