### PR TITLE
Update editor text as color is changed

### DIFF
--- a/lib/ColorPicker-view.coffee
+++ b/lib/ColorPicker-view.coffee
@@ -414,6 +414,9 @@
 
             @storage.pickedColor = _displayColor
 
+            # Update the editor with the current color
+            @replaceColor()
+
             # Set the color
             (@find '#ColorPicker-color')
                 .css 'background-color', _color
@@ -531,4 +534,8 @@
                 end:
                     column: _color.index + _newColor.length
                     row: _color.row
+
+            # Update buffer selection stats, since the new
+            # color may have a different length.
+            _color.end = _color.index + _newColor.length
             return


### PR DESCRIPTION
Make color-picker even more awesome when used in combination with an
as-you-type CSS reloader. In this scenario, a developer can keep the
color picker open as they see the impact of their color choice in
the reloaded interface.

As a bonus, the undo history can walk backwards through color selections.