### PR TITLE
Add support for scrolling to change values

### DIFF
--- a/lib/ColorPicker-view.coffee
+++ b/lib/ColorPicker-view.coffee
@@ -99,6 +99,12 @@
                 _isPickerEvent = @element.hasChild e.target
                 @emitMouseUp e, _isPickerEvent]
             window.addEventListener 'mouseup', onMouseUp
+            
+            @listeners.push ['mousewheel', onMouseWheel = (e) =>
+                return unless @element.isOpen();
+                _isPickerEvent = @element.hasChild e.target
+                @emitMouseWheel e, _isPickerEvent]
+            window.addEventListener 'mousewheel', onMouseWheel
 
             _workspaceView.addEventListener 'keydown', (e) =>
                 return unless @element.isOpen()
@@ -168,6 +174,11 @@
             @Emitter.emit 'mouseUp', e, isOnPicker
         onMouseUp: (callback) ->
             @Emitter.on 'mouseUp', callback
+        
+        emitMouseWheel: (e, isOnPicker) ->
+            @Emitter.emit 'mouseWheel', e, isOnPicker
+        onMouseWheel: (callback) ->
+            @Emitter.on 'mouseWheel', callback
 
         # Key events
         emitKeyDown: (e, isOnPicker) ->

--- a/lib/extensions/Alpha.coffee
+++ b/lib/extensions/Alpha.coffee
@@ -136,7 +136,7 @@
                         y: 0
                         color: null
                         alpha: null
-                    setSelection: (e, alpha=null) ->
+                    setSelection: (e, alpha=null, offset=null) ->
                         _rect = Alpha.element.getRect()
 
                         if e then _y = e.pageY - _rect.top
@@ -144,6 +144,8 @@
                         else if (typeof alpha is 'number')
                             _y = _rect.height - (alpha * _rect.height) # reversed, 1 is top
                         # Default to previous values
+                        else if (typeof offset is 'number')
+                            _y = @selection.y+offset
                         else _y = @selection.y
 
                         _y = @selection.y = Math.max 0, (Math.min _rect.height, _y)
@@ -199,6 +201,13 @@
                     return unless @control.isGrabbing
                     @control.isGrabbing = no
                     @control.setSelection e
+                    
+                colorPicker.onMouseWheel (e, isOnPicker) =>
+                    return unless isOnPicker and hasChild Alpha.element.el, e.target
+                    e.preventDefault()
+                    
+                    direction = if e.deltaY > 0 then 1 else -1;
+                    @control.setSelection null, null, direction
 
                 # Add to Alpha element
                 @element.add @control.el

--- a/lib/extensions/Format.coffee
+++ b/lib/extensions/Format.coffee
@@ -55,6 +55,7 @@
                     # alpha channel
                     if format is _button.format or format is "#{ _button.format }A"
                         _button.activate()
+                        _activeButton = _button
                     else _button.deactivate()
 
                 # Create formatting buttons
@@ -86,13 +87,6 @@
                             _button.activate()
 
                     # Change color format on click
-                    hasChild = (element, child) ->
-                        if child and _parent = child.parentNode
-                            if child is element
-                                return true
-                            else return hasChild element, _parent
-                        return false
-
                     _isClicking = no
 
                     colorPicker.onMouseDown (e, isOnPicker) =>
@@ -114,5 +108,34 @@
 
                     # Add button to the parent Format element
                     @element.add _button.el
+
+                # Change format button when scrolling over the list of buttons
+                colorPicker.onMouseWheel (e, isOnPicker) =>
+                    return unless isOnPicker and hasChild @element.el, e.target
+                    e.preventDefault()
+                        
+                    direction = if e.deltaY > 0 then 1 else -1;
+                    newButtonIndex = _buttons.indexOf(_activeButton) + direction;
+                    if newButtonIndex >= _buttons.length
+                        newButtonIndex = 0
+                    else if newButtonIndex < 0
+                        newButtonIndex = _buttons.length - 1
+
+                    newButton = _buttons[newButtonIndex]
+                    
+                    if newButton
+                        _activeButton.deactivate() if _activeButton
+                        newButton.activate()
+                        _activeButton = newButton
+
+                        @emitFormatChanged newButton.format
                 return
             return this
+
+    # Utility function to determine whether the elmenet has a the specified child.
+    hasChild = (element, child) ->
+        if child and _parent = child.parentNode
+            if child is element
+                return true
+            else return hasChild element, _parent
+        return false

--- a/lib/extensions/Hue.coffee
+++ b/lib/extensions/Hue.coffee
@@ -188,6 +188,13 @@
                     return unless @control.isGrabbing
                     @control.isGrabbing = no
                     @control.setSelection e
+                
+                colorPicker.onMouseWheel (e, isOnPicker) =>
+                    return unless isOnPicker and hasChild Hue.element.el, e.target
+                    e.preventDefault()
+                    
+                    direction = if e.deltaY > 0 then 1 else -1
+                    @control.setSelection null, @control.selection.y+direction
 
                 # Add to Hue element
                 @element.add @control.el


### PR DESCRIPTION
Adds:
* Scroll on the format buttons to switch formats
* Scroll on the Alpha and Hue sliders to lower and raise the value by small increments. This allows for considerably more precision than clicking.

Fixes:
* On re-opening the color picker, the active button was visually but not internally reset properly, which had the potential to cause issues in the future.

Notes:
* Does not add scroll interactions for the Saturation/Value field. I'm not sure what a good way to implement this would be.
* Scrolling on the page is not affected and behaves in the same way as before, closing the color picker.

Oh, and this is my first time writing CoffeeScript, so you might want to scan it real close for bugs.