### PR TITLE
Use atom.keymaps instead of deprecated atom.keymap

### DIFF
--- a/lib/ColorPicker.coffee
+++ b/lib/ColorPicker.coffee
@@ -29,7 +29,7 @@
             _keymap["#{ _linuxSelector }"]["ctrl-alt-#{ _triggerKey }"] = _command
 
             # Add the keymap
-            atom.keymap.add 'color-picker:trigger', _keymap
+            atom.keymaps.add 'color-picker:trigger', _keymap
 
         #  Add context menu command
         # ---------------------------


### PR DESCRIPTION
`atom --one` throws `Cannot read property 'add' of undefined` because `atom.keymap` is deprecated.