### PR TITLE
:racehorese: Enhance null check for rgbToHsv in Convert.coffee

### DIFF
--- a/lib/modules/Convert.coffee
+++ b/lib/modules/Convert.coffee
@@ -82,8 +82,8 @@
             computedV = 0
 
             for elem in [r, g, b]
-              if not elem? or isNaN(elem) or elem < 0 or elem > 255
-                return
+                if not elem? or isNaN(elem) or elem < 0 or elem > 255
+                    return
 
             r = r / 255
             g = g / 255

--- a/lib/modules/Convert.coffee
+++ b/lib/modules/Convert.coffee
@@ -81,9 +81,8 @@
             computedS = 0
             computedV = 0
 
-            if not r? or not g? or not b? or isNaN(r) or isNaN(g) or isNaN(b)
-                return
-            if r < 0 or g < 0 or b < 0 or r > 255 or g > 255 or b > 255
+            for elem in [r, g, b]
+              if not elem? or isNaN(elem) or elem < 0 or elem > 255
                 return
 
             r = r / 255


### PR DESCRIPTION
# What

How about updated algorithm of checking arguments in rgbToHsv in Convert.coffee
# Why
- I think, in the former calculation unnecessary checking would occur...
- And maybe this would be a little bit more readable
