### PR TITLE
Use TextEditor::pixelRectForScreenRange instead of Marker::getPixelRange

### DIFF
--- a/lib/ColorPicker-view.coffee
+++ b/lib/ColorPicker-view.coffee
@@ -357,10 +357,10 @@
             # the middle of the selection range
             # TODO: There can be lines over more than one row
             if _match
-                {left, width} = Editor.pixelRectForScreenRange(_selection.getScreenRange())
-                right = left + width
+                _rect = Editor.pixelRectForScreenRange(_selection.getScreenRange())
+                _right = _rect.left + _rect.width
                 _cursorPosition = Cursor.getPixelRect()
-                _cursorPosition.left = right - (width / 2)
+                _cursorPosition.left = _right - (_rect.width / 2)
 
         #  Figure out where to place the Color Picker
         # ---------------------------

--- a/lib/ColorPicker-view.coffee
+++ b/lib/ColorPicker-view.coffee
@@ -358,9 +358,8 @@
             # TODO: There can be lines over more than one row
             if _match
                 {left, width} = Editor.pixelRectForScreenRange(_selection.getScreenRange())
-                right = left + width
                 _cursorPosition = Cursor.getPixelRect()
-                _cursorPosition.left = right - ((right - left) / 2)
+                _cursorPosition.left = right - (width / 2)
 
         #  Figure out where to place the Color Picker
         # ---------------------------

--- a/lib/ColorPicker-view.coffee
+++ b/lib/ColorPicker-view.coffee
@@ -358,6 +358,7 @@
             # TODO: There can be lines over more than one row
             if _match
                 {left, width} = Editor.pixelRectForScreenRange(_selection.getScreenRange())
+                right = left + width
                 _cursorPosition = Cursor.getPixelRect()
                 _cursorPosition.left = right - (width / 2)
 

--- a/lib/ColorPicker-view.coffee
+++ b/lib/ColorPicker-view.coffee
@@ -357,9 +357,10 @@
             # the middle of the selection range
             # TODO: There can be lines over more than one row
             if _match
-                _selectionRect = Editor.pixelRectForScreenRange(_selection.getScreenRange())
+                {left, width} = Editor.pixelRectForScreenRange(_selection.getScreenRange())
+                right = left + width
                 _cursorPosition = Cursor.getPixelRect()
-                _cursorPosition.left = _selectionRect.right - ((_selectionRect.right - _selectionRect.left) / 2)
+                _cursorPosition.left = right - ((right - left) / 2)
 
         #  Figure out where to place the Color Picker
         # ---------------------------

--- a/lib/ColorPicker-view.coffee
+++ b/lib/ColorPicker-view.coffee
@@ -357,9 +357,9 @@
             # the middle of the selection range
             # TODO: There can be lines over more than one row
             if _match
-                _selectionPosition = _selection.marker.getPixelRange()
+                _selectionRect = Editor.pixelRectForScreenRange(_selection.getScreenRange())
                 _cursorPosition = Cursor.getPixelRect()
-                _cursorPosition.left = _selectionPosition.end.left - ((_selectionPosition.end.left - _selectionPosition.start.left) / 2)
+                _cursorPosition.left = _selectionRect.right - ((_selectionRect.right - _selectionRect.left) / 2)
 
         #  Figure out where to place the Color Picker
         # ---------------------------


### PR DESCRIPTION
This replaces `Marker::getPixelRange` with `TextEditor::pixelRectForScreenRange`, because the former was not part of the public API and will, therefore, be dropped in the next version of Atom (see https://github.com/atom/atom/pull/8905 for further information).

Please, note that starting from the next version we're going to deprecate all those methods in `TextEditor` that refer to pixel coordinates (e.g. `::setScrollTop`, `::pixelPositionForScreenPosition`, `::pixelRectForScreenRange`, etc.). You will still be able to use them, but we discourage it as they might disappear in a future version. These methods will be moved to `TextEditorElement` and, therefore, we recommend using those ones instead.

Unfortunately, I wasn't able to verify against some specs that the change I applied in this PR worked correctly. However, it seems to be fine from a cursory manual test.

Please, let me know if I can improve this somehow. Thanks! :bow: 

/cc: @thomaslindstrom 