### PR TITLE
Fix for issue #172: Picker opens in wrong position where there is a left sidebar

### DIFF
--- a/lib/ColorPicker-view.coffee
+++ b/lib/ColorPicker-view.coffee
@@ -387,6 +387,11 @@
                     # Make sure the Color Picker isn't too far to the right
                     _x = Math.min (@Parent.offsetWidth - _colorPickerWidth - 10), _x
 
+                    # Move to the left if there is a left panel
+                    _leftPanel = (atom.views.getView atom.workspace).querySelector 'atom-panel-container.left'
+                    if _leftPanel
+                        _x += _leftPanel.offsetWidth
+
                     return _x
                 y: do =>
                     @element.unflip()

--- a/lib/extensions/Arrow.coffee
+++ b/lib/extensions/Arrow.coffee
@@ -81,5 +81,9 @@
         #  Place the Arrow
         # ---------------------------
             colorPicker.onPositionChange (position, colorPickerPosition) =>
+                _leftPanel = (atom.views.getView atom.workspace).querySelector 'atom-panel-container.left'
+                if _leftPanel
+                    @element.setPosition position.x - (colorPickerPosition.x - _leftPanel.offsetWidth)
+                else
                 @element.setPosition position.x - colorPickerPosition.x
             return this


### PR DESCRIPTION
This fixes #172, moving picker view to the left where there's a left panel. In case there's no left panel, nothing is changed.