### PR TITLE
Add initial top/left properties

### DIFF
--- a/styles/ColorPicker.less
+++ b/styles/ColorPicker.less
@@ -4,6 +4,8 @@
 
     .ColorPicker {
         height: 0; // Height is computed
+        top: 0; // Top is computed
+        left: 0; // Left is computed
         position: absolute;
         visibility: hidden;
         opacity: 0;


### PR DESCRIPTION
This should fix an issue with header panels getting pushed up too much. In this case `tool-bar`.

Note: I couldn't reproduce this issue myself, but props to @jerone + @abdelouahabb who figured it all out. :clap: :heart: 

Closes https://github.com/suda/tool-bar/issues/130