### PR TITLE
Fix compatibilty with Tool Bar package

### DIFF
--- a/styles/ColorPicker.less
+++ b/styles/ColorPicker.less
@@ -5,15 +5,14 @@
     .ColorPicker {
         height: 0; // Height is computed
         position: absolute;
-        visibility: hidden;
+        display: none;
         opacity: 0;
         pointer-events: none;
         user-select: none;
         z-index: 100;
 
         transition:
-            opacity             .15s,
-            visibility        0 .15s;
+            opacity             .15s;
         backface-visibility: hidden;
         transform-style: preserve-3d;
 
@@ -21,7 +20,7 @@
     //  : `is open` modifier
     // -------------------------------------
         &.is--open {
-            visibility: visible;
+            display: block;
             opacity: 1;
             pointer-events: all;
 


### PR DESCRIPTION
This fixes an issue with header panels getting pushed up, when packages make use of the `atom.workspace.addHeaderPanel` API (e.g. the Tool Bar package).

Closes suda/tool-bar#130

This will permanently disable the visibility animation, but because of an [invalid value](https://github.com/suda/tool-bar/issues/130#issuecomment-201401918) this didn't even work.

Steps to reproduce can be found at https://github.com/suda/tool-bar/issues/130