### PR TITLE
Add initial top/left properties

### DIFF
--- a/styles/ColorPicker.less
+++ b/styles/ColorPicker.less
@@ -4,6 +4,8 @@
 
     .ColorPicker {
         height: 0; // Height is computed
+        top: 0; // Top is computed
+        left: 0; // Left is computed
         position: absolute;
         visibility: hidden;
         opacity: 0;


### PR DESCRIPTION
This should fix an issue with header panels getting pushed up too much.

I guess without the `top: 0`, the color-picker's natural position is below the status-bar (footer), causing the shifting reported in https://github.com/suda/tool-bar/issues/130 + https://github.com/atom/atom/pull/11790#issuecomment-230154158.

Before | After
--- | ---
![screen shot 2016-07-08 at 3 42 34 pm](https://cloud.githubusercontent.com/assets/378023/16679461/bcee6edc-4522-11e6-9457-f465e509614b.png) | ![screen shot 2016-07-08 at 3 43 15 pm](https://cloud.githubusercontent.com/assets/378023/16679466/c47758c6-4522-11e6-8935-a14a4f1fea4f.png)