### PR TITLE
Exclude non-essential files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,4 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.npmignore export-ignore
-/CHANGELOG.md export-ignore
-/README.md export-ignore
 /preview.gif export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto
+
+/docs export-ignore
+/spec export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.npmignore export-ignore
+/CHANGELOG.md export-ignore
+/README.md export-ignore
+/preview.gif export-ignore


### PR DESCRIPTION
This way the users of this package doesn't have to download non-essential files which aren't necessary for the package to function. Such as files used for development (docs, tests, .travis.yml, etc).

Happy Hacktoberfest!