### PR TITLE
Add option to always display alpha and fix vec4 alpha to always be float

### DIFF
--- a/lib/ColorPicker.coffee
+++ b/lib/ColorPicker.coffee
@@ -71,6 +71,12 @@
                 description: 'Replace selected color automatically on change. Works well with as-you-type CSS reloaders.'
                 type: 'boolean'
                 default: false
+            # Always output alpha value
+            alphaChannelAlways:
+                title: 'Always include alpha channel value'
+                description: 'Output alpha channel value, even if it is 1.0'
+                type: 'boolean'
+                default: false
             # Abbreviate values configuration: If possible, abbreviate color values. Eg. “0.3” to “.3”
             # TODO: Can we abbreviate something else?
             abbreviateValues:

--- a/lib/extensions/Color.coffee
+++ b/lib/extensions/Color.coffee
@@ -45,7 +45,7 @@
                 setColor: (smartColor) ->
                     _color = smartColor.toRGBA()
                     return if @previousColor and @previousColor is _color
-                    
+
                     @el.style.backgroundColor = _color
                     return @previousColor = _color
             colorPicker.element.add @element.el
@@ -133,7 +133,7 @@
                     _format = _formatFormat or _inputColor?.format or _preferredFormat or 'RGB'
 
                     # TODO: This is very fragile
-                    _function = if smartColor.getAlpha() < 1
+                    _function = if smartColor.getAlpha() < 1 || atom.config.get 'color-picker.alphaChannelAlways'
                         (smartColor["to#{ _format }A"] or smartColor["to#{ _format }"])
                     else smartColor["to#{ _format }"]
 

--- a/lib/modules/SmartColor.coffee
+++ b/lib/modules/SmartColor.coffee
@@ -182,7 +182,7 @@
                 toVECA: ->
                     _vecaArray = @toVECAArray()
                     return s "vec4(#{ f _vecaArray[0] }, #{ f _vecaArray[1] }, #{ f _vecaArray[2] }, #{ f _vecaArray[3] })"
-                toVECAArray: -> @toVECArray().concat [@getAlpha()]
+                toVECAArray: -> @toVECArray().concat [(@getAlpha()).toFixed 2]
 
             #  HEX
             # ---------------------------


### PR DESCRIPTION
Just as the title says 😄 

- Currently when alpha is _1_, it is not outputted -> Newly added settings toggle can force to always output alpha.
- Currently when alpha is _1_ and it is outputted it stays _1_ which is a no go for vec4 -> thus this pull also addresses to always output float _1.0_ in this case.
